### PR TITLE
Follow convention for mappings.tiny path

### DIFF
--- a/src/main/java/org/quiltmc/mappings_hasher/Main.java
+++ b/src/main/java/org/quiltmc/mappings_hasher/Main.java
@@ -160,7 +160,9 @@ public class Main implements Callable<Integer> {
         MappingSet mappingSet = mappingsHasher.generate(new JarFile(clientJar.toFile()), classInfo -> true);
 
         if (outFile == null) {
-            outFile = Paths.get("mappings", "hashed-" + version.getId() + ".tiny");
+            // Previous outFile path - breaks Tiny convention for mappings location
+            // outFile = Paths.get("mappings", "hashed-" + version.getId() + ".tiny");
+            outFile = Paths.get("mappings", "mappings.tiny");
         }
 
         System.out.println("Writing mappings...");


### PR DESCRIPTION
Fixes #4.

Currently, Mappings Hasher exports its mappings to `mappings/hashed-<version ID>.tiny`. This, sadly, breaks convention for tiny mapping locations, causing issues with VanillaGradle, Loom, and other plugins.

This change may require changes elsewhere, and configurable options may be added later. However, it is probably a good idea to follow the standard convention.

~Alice