### PR TITLE
Update Quilt Meta CI

### DIFF
--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -36,9 +36,10 @@ jobs:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      - name: Refresh Meta
-        uses: fjogeleit/http-request-action@master
+
+      - name: Update Quilt Meta
+        uses: quiltmc/update-quilt-meta@main
         with:
-          url: ${{ secrets.META_UPDATE_URL }}
-          method: 'GET'
-          preventFailureOnNoResponse: true
+          b2-key-id: ${{ secrets.META_B2_KEY_ID }}
+          b2-key: ${{ secrets.META_B2_KEY }}
+          cf-key: ${{ secrets.META_CF_KEY }}

--- a/.github/workflows/generate-and-publish-experimental.yml
+++ b/.github/workflows/generate-and-publish-experimental.yml
@@ -27,9 +27,10 @@ jobs:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      - name: Refresh Meta
-        uses: fjogeleit/http-request-action@master
+
+      - name: Update Quilt Meta
+        uses: quiltmc/update-quilt-meta@main
         with:
-          url: ${{ secrets.META_UPDATE_URL }}
-          method: 'GET'
-          preventFailureOnNoResponse: true
+          b2-key-id: ${{ secrets.META_B2_KEY_ID }}
+          b2-key: ${{ secrets.META_B2_KEY }}
+          cf-key: ${{ secrets.META_CF_KEY }}

--- a/.github/workflows/generate-and-publish.yml
+++ b/.github/workflows/generate-and-publish.yml
@@ -24,9 +24,10 @@ jobs:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      - name: Refresh Meta
-        uses: fjogeleit/http-request-action@master
+
+      - name: Update Quilt Meta
+        uses: quiltmc/update-quilt-meta@main
         with:
-          url: ${{ secrets.META_UPDATE_URL }}
-          method: 'GET'
-          preventFailureOnNoResponse: true
+          b2-key-id: ${{ secrets.META_B2_KEY_ID }}
+          b2-key: ${{ secrets.META_B2_KEY }}
+          cf-key: ${{ secrets.META_CF_KEY }}


### PR DESCRIPTION
This commit removes the HTTP request task and replaces it by the new GitHub Actions setup.

Draft until the last secret is added to the organisation.